### PR TITLE
Allow QCPortal 0.52+ with Pydantic v2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ outputs:
         - msgpack-python
         - requests
         - pyyaml
-        - pydantic >=1.10,<2.0
+        - pydantic >=1.10,<3.0a0
         - zstandard
         - qcelemental
         - tabulate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     folder: qcarchivetesting
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:


### PR DESCRIPTION
0.52 of the stack was meant to allow Pydantic v2 at runtime, but the dependency constraints were not updated to reflect that (https://github.com/MolSSI/QCFractal/pull/787). Here's my stab at doing that.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
